### PR TITLE
Add gpg_home and sign_key parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2017-07-27 - Scott Brimhall <sbrimhall@salesforce.com> - 1.2.4
+* Fork golja/gnupg and add gpg_home and sign_key parameters
+
 2016-01-22 - Dejan Golja <dejan@golja.org> - 1.2.3
 * Another retry to rebuild repack the module to fix the PaxHeaders bsd tar bug
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#GnuPG puppet module
+# GnuPG puppet module
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview](##overview)
 2. [Installation](##Installation)
@@ -10,7 +10,7 @@
 6. [Development - Guide for contributing to the module](##development)
 7. [License](##license)
 
-##Overview
+## Overview
 
 Install GnuPG on Ubuntu/Debian/RedHat/CentOS/Amazon AMI and manage users public keys.
 
@@ -20,17 +20,17 @@ NOTE: For puppet 2.7.x supported module please use version 0.X.X
 
 [![Build Status](https://travis-ci.org/n1tr0g/golja-gnupg.png)](https://travis-ci.org/n1tr0g/golja-gnupg) [![Puppet Forge](http://img.shields.io/puppetforge/v/golja/gnupg.svg)](https://forge.puppetlabs.com/golja/gnupg)
 
-##Installation
+## Installation
 
      $ puppet module install golja/gnupg
 
-##Usage
+## Usage
 
-####Install GnuPG package
+#### Install GnuPG package
 
     include '::gnupg'
 
-####Add public key 20BC0A86 from PGP server from hkp://pgp.mit.edu/ to user root
+#### Add public key 20BC0A86 from PGP server from hkp://pgp.mit.edu/ to user root
 
 ```puppet
 gnupg_key { 'hkp_server_20BC0A86':
@@ -44,7 +44,7 @@ gnupg_key { 'hkp_server_20BC0A86':
 }
 ```
 
-####Add public key D50582E6 from standard http URI to user foo
+#### Add public key D50582E6 from standard http URI to user foo
 
 ```puppet
 gnupg_key { 'jenkins_foo_key':
@@ -58,7 +58,7 @@ gnupg_key { 'jenkins_foo_key':
 }
 ```
 
-####Add public key D50582E6 from puppet fileserver to user foo
+#### Add public key D50582E6 from puppet fileserver to user foo
 
 ```puppet
 gnupg_key { 'jenkins_foo_key':
@@ -72,7 +72,7 @@ gnupg_key { 'jenkins_foo_key':
 }
 ```
 
-####Add public key D50582E6 from puppet fileserver to user bar via a string value
+#### Add public key D50582E6 from puppet fileserver to user bar via a string value
 
 ```puppet
 gnupg_key { 'jenkins_foo_key':
@@ -87,7 +87,7 @@ gnupg_key { 'jenkins_foo_key':
 ```
 *Note*: You should use hiera lookup to get the key content
 
-####Remove public key 20BC0A86 from user root
+#### Remove public key 20BC0A86 from user root
 
 ```puppet
 gnupg_key {'root_remove':
@@ -98,7 +98,7 @@ gnupg_key {'root_remove':
 }
 ```
 
-###Remove both private and public key 20BC0A66
+### Remove both private and public key 20BC0A66
 
 ```puppet
 gnupg_key {'root_remove':
@@ -109,40 +109,40 @@ gnupg_key {'root_remove':
 }
 ```
 
-##Reference
+## Reference
 
-###Classes
+### Classes
 
-####gnupg
+#### gnupg
 
-#####`package_ensure`
+##### `package_ensure`
 
 Valid value present/absent. In most cases you should never uninstall this package,
 because most of the modern Linux distros rely on gnupg for package verification, etc
 Default: present
 
-#####`package_name`
+##### `package_name`
 
 Name of the GnuPG package. Default value determined by $::osfamily/$::operatingsystem facts
 
-####gnupg_key
+#### gnupg_key
 
-#####`ensure`
+##### `ensure`
 
 **REQUIRED** - Valid value present/absent
 
-#####`user`
+##### `user`
 
 **REQUIRED** - System username for who to store the public key. Also define the location of the 
 pubring (default ${HOME}/.gnupg/)
 
-#####`key_id`
+##### `key_id`
 
 **REQUIRED** - Key ID. Usually the traditional 8-character key ID. Also accepted the
 long more accurate (but  less  convenient) 16-character key ID. Accept only hexadecimal
 values.
 
-#####`key_source`
+##### `key_source`
 
 **REQUIRED** if `key_server` or `key_content` is not defined and `ensure` is present.
 A source file containing PGP key. Values can be URIs pointing to remote files,
@@ -154,14 +154,14 @@ usually formatted as:
 
 puppet:///modules/name_of_module/filename
 
-#####`key_server`
+##### `key_server`
 
 **REQUIRED** if `key_source` or `key_content` is not defined and `ensure` is present.
 
 PGP key server from where to retrieve the public key. Valid URI schemes are
 *http*, *https*, *ldap* and *hkp*.
 
-#####`key_content`
+##### `key_content`
 
 **REQUIRED** if `key_server` or `key_source` is not defined and `ensure` is present.
 
@@ -170,21 +170,21 @@ hiera property and the consumer doesn't want to have to write that content to a 
 before the gnupg_key resource executes.
 
 
-#####`key_type`
+##### `key_type`
 
 **OPTIONAL** - key type. Valid values (public|private|both). Default: public
 
-#####`proxy`
+##### `proxy`
 
 **OPTIONAL** - use a http proxy url to access the keyserver, for example: http://proxy.corp.domain:80.  Default: undef
 
-#####`gpg_home`
+##### `gpg_home`
 
 **OPTIONAL** - The absolute path to use for --homedir with the gpg command.  This is required when configuring
 GPG keys for hiera-eyaml-gpg on a puppet server.  Must be a path that is accessible by the user
 defined in the `user` parameter.
 
-#####`sign_key`
+##### `sign_key`
 
 **OPTIONAL** - Boolean - Whether to sign an imported key or not
 
@@ -223,7 +223,7 @@ Alernatively you can run beaker tests using:
 
     bundle exec rake beaker
 
-##Limitations
+## Limitations
 
 This module has been tested on:
 
@@ -233,7 +233,7 @@ This module has been tested on:
 * CentOS 5/6/7
 * Amazon AMI
 
-##Development
+## Development
 
 Please see CONTRIBUTING.md
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ gnupg_key { 'hkp_server_20BC0A86':
   ensure     => present,
   key_id     => '20BC0A86',
   user       => 'root',
+  gpg_home   => '/root/.gnupg',
+  sign_key   => true,
   key_server => 'hkp://pgp.mit.edu/',
   key_type   => public,
 }
@@ -49,6 +51,8 @@ gnupg_key { 'jenkins_foo_key':
   ensure     => present,
   key_id     => 'D50582E6',
   user       => 'foo',
+  gpg_home   => '/root/.gnupg',
+  sign_key   => true,
   key_source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
   key_type   => public,
 }
@@ -61,6 +65,8 @@ gnupg_key { 'jenkins_foo_key':
   ensure     => present,
   key_id     => 'D50582E6',
   user       => 'foo',
+  gpg_home   => '/root/.gnupg',
+  sign_key   => true,
   key_source => 'puppet:///modules/gnupg/D50582E6.key',
   key_type   => public,
 }
@@ -73,6 +79,8 @@ gnupg_key { 'jenkins_foo_key':
   ensure      => present,
   key_id      => 'D50582E6',
   user        => 'bar',
+  gpg_home   => '/root/.gnupg',
+  sign_key   => true,
   key_content => '-----BEGIN BROKEN PUBLIC KEY BLOCK-----...',
   key_type    => public,
 }
@@ -169,6 +177,16 @@ before the gnupg_key resource executes.
 #####`proxy`
 
 **OPTIONAL** - use a http proxy url to access the keyserver, for example: http://proxy.corp.domain:80.  Default: undef
+
+#####`gpg_home`
+
+**OPTIONAL** - The absolute path to use for --homedir with the gpg command.  This is required when configuring
+GPG keys for hiera-eyaml-gpg on a puppet server.  Must be a path that is accessible by the user
+defined in the `user` parameter.
+
+#####`sign_key`
+
+**OPTIONAL** - Boolean - Whether to sign an imported key or not
 
 ### Tests
 

--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
   end
 
   def sign_key
-    unless resource[:sign_key].nil? or resource[:sign_key] == false
+    if resource[:sign_key]
       sign_command = "#{gpg_command} --batch --yes --sign-key #{resource[:key_id]}"
       begin
         sign_output = Puppet::Util::Execution.execute(sign_command, :uid => user_id, :failonfail => true)

--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -25,12 +25,17 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
       raise Puppet::Error, "Could not determine fingerprint for  #{resource[:key_id]} for user #{resource[:user]}: #{fingerprint}"
     end
 
+    if resource[:gpg_home].nil?
+      gpg_command = "gpg"
+    else
+      gpg_command = "gpg --homedir #{resource[:gpg_home]}"
+    end
     if resource[:key_type] == :public
-      command = "gpg --batch --yes --delete-key #{fingerprint}"
+      command = "#{gpg_command} --batch --yes --delete-key #{fingerprint}"
     elsif resource[:key_type] == :private
-      command = "gpg --batch --yes --delete-secret-key #{fingerprint}"
+      command = "#{gpg_command} --batch --yes --delete-secret-key #{fingerprint}"
     elsif resource[:key_type] == :both
-      command = "gpg --batch --yes --delete-secret-and-public-key #{fingerprint}"
+      command = "#{gpg_command} --batch --yes --delete-secret-and-public-key #{fingerprint}"
     end
 
     begin
@@ -53,15 +58,28 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
   end
 
   def add_key_from_key_server
-    if resource[:proxy].empty?
-      command = "gpg --keyserver #{resource[:key_server]} --recv-keys #{resource[:key_id]}"
+    if resource[:gpg_home].nil?
+      gpg_command = "gpg"
     else
-      command = "gpg --keyserver #{resource[:key_server]} --keyserver-options http-proxy=#{resource[:proxy]} --recv-keys #{resource[:key_id]}"
+      gpg_command = "gpg --homedir #{resource[:gpg_home]}"
+    end
+    if resource[:proxy].nil?
+      command = "#{gpg_command} --keyserver #{resource[:key_server]} --recv-keys #{resource[:key_id]}"
+    else
+      command = "#{gpg_command} --keyserver #{resource[:key_server]} --keyserver-options http-proxy=#{resource[:proxy]} --recv-keys #{resource[:key_id]}"
     end
     begin
       output = Puppet::Util::Execution.execute(command,  :uid => user_id, :failonfail => true)
     rescue Puppet::ExecutionFailure => e
       raise Puppet::Error, "Key #{resource[:key_id]} does not exist on #{resource[:key_server]}"
+    end
+    unless resource[:sign_key].nil? or resource[:sign_key] == false
+      sign_command = "#{gpg_command} --batch --yes --sign-key #{resource[:key_id]}"
+      begin
+        sign_output = Puppet::Util::Execution.execute(sign_command, :uid => user_id, :failonfail => true)
+      rescue Puppet::ExecutionFailure => e
+        raise Puppet::Error, "Key #{resource[:key_id]} does not exist or could not be signed."
+      end
     end
   end
 
@@ -75,21 +93,47 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
 
   def add_key_from_key_content
     path = create_temporary_file(user_id, resource[:key_content])
-    command = "gpg --import #{path}"
+    if resource[:gpg_home].nil?
+      gpg_command = "gpg"
+    else
+      gpg_command = "gpg --homedir #{resource[:gpg_home]}"
+    end
+    command = "#{gpg_comamnd} --batch --import #{path}"
     begin
       output = Puppet::Util::Execution.execute(command, :uid => user_id, :failonfail => true)
     rescue Puppet::ExecutionFailure => e
       raise Puppet::Error, "Error while importing key #{resource[:key_id]} using key content:\n#{output}}"
     end
+    unless resource[:sign_key].nil? or resource[:sign_key] == false
+      sign_command = "#{gpg_command} --batch --yes --sign-key #{resource[:key_id]}"
+      begin
+        sign_output = Puppet::Util::Execution.execute(sign_command, :uid => user_id, :failonfail => true)
+      rescue Puppet::ExecutionFailure => e
+        raise Puppet::Error, "Key #{resource[:key_id]} does not exist or could not be signed."
+      end
+    end
   end
 
   def add_key_at_path
     if File.file?(resource[:key_source])
-      command = "gpg --import #{resource[:key_source]}"
+      if resource[:gpg_home].nil?
+        gpg_command = "gpg"
+      else
+        gpg_command = "gpg --homedir #{resource[:gpg_home]}"
+      end
+      command = "#{gpg_command} --batch --import #{resource[:key_source]}"
       begin
         output = Puppet::Util::Execution.execute(command, :uid => user_id, :failonfail => true)
       rescue Puppet::ExecutionFailure => e
         raise Puppet::Error, "Error while importing key #{resource[:key_id]} from #{resource[:key_source]}"
+      end
+      unless resource[:sign_key].nil? or resource[:sign_key] == false
+        sign_command = "#{gpg_command} --batch --yes --sign-key #{resource[:key_id]}"
+        begin
+          sign_output = Puppet::Util::Execution.execute(sign_command, :uid => user_id, :failonfail => true)
+        rescue Puppet::ExecutionFailure => e
+          raise Puppet::Error, "Key #{resource[:key_id]} does not exist or could not be signed."
+        end
       end
     elsif
       raise Puppet::Error, "Local file #{resource[:key_source]} for #{resource[:key_id]} does not exists"
@@ -97,20 +141,33 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
   end
 
   def add_key_at_url
+    if resource[:gpg_home].nil?
+      gpg_command = "gpg"
+    else
+      gpg_command = "gpg --homedir #{resource[:gpg_home]}"
+    end
     uri = URI.parse(URI.escape(resource[:key_source]))
     case uri.scheme
     when /https/
-      command = "wget -O- #{resource[:key_source]} | gpg --import"
+      command = "wget -O- #{resource[:key_source]} | #{gpg_command} --batch --import"
     when /http/
-      command = "gpg --fetch-keys #{resource[:key_source]}"
+      command = "#{gpg_command} --fetch-keys #{resource[:key_source]}"
     when 'puppet'
       path = create_temporary_file user_id, puppet_content
-      command = "gpg --import #{path}"
+      command = "#{gpg_command} --batch --import #{path}"
     end
     begin
       output = Puppet::Util::Execution.execute(command, :uid => user_id, :failonfail => true)
     rescue Puppet::ExecutionFailure => e
       raise Puppet::Error, "Error while importing key #{resource[:key_id]} from #{resource[:key_source]}:\n#{output}}"
+    end
+    unless resource[:sign_key].nil? or resource[:sign_key] == false
+      sign_command = "#{gpg_command} --batch --yes --sign-key #{resource[:key_id]}"
+      begin
+        sign_output = Puppet::Util::Execution.execute(sign_command, :uid => user_id, :failonfail => true)
+      rescue Puppet::ExecutionFailure => e
+        raise Puppet::Error, "Key #{resource[:key_id]} does not exist or could not be signed."
+      end
     end
   end
 
@@ -144,10 +201,15 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
     # public and both can be grouped since private can't be present without public,
     # both only applies to delete and delete still has something to do if only
     # one of the keys is present
+    if resource[:gpg_home].nil?
+      gpg_command = "gpg"
+    else
+      gpg_command = "gpg --homedir #{resource[:gpg_home]}"
+    end
     if resource[:key_type] == :public || resource[:key_type] == :both
-      command = "gpg --list-keys --with-colons #{resource[:key_id]}"
+      command = "#{gpg_command} --list-keys --with-colons #{resource[:key_id]}"
     elsif resource[:key_type] == :private
-      command = "gpg --list-secret-keys --with-colons #{resource[:key_id]}"
+      command = "#{gpg_command} --list-secret-keys --with-colons #{resource[:key_id]}"
     end
 
     output = Puppet::Util::Execution.execute(command, :uid => user_id)

--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -59,8 +59,7 @@ Puppet::Type.newtype(:gnupg_key) do
   end
 
   newparam(:user) do
-    desc "The user account in which the PGP public key should be installed.
-    Usually it's stored in HOME/.gnupg/ dir"
+    desc "The user account in which the PGP public key should be installed."
 
     validate do |value|
       # freebsd/linux username limitation
@@ -68,6 +67,28 @@ Puppet::Type.newtype(:gnupg_key) do
         raise ArgumentError, "Invalid username format for #{value}"
       end
     end
+  end
+
+  newparam(:gpg_home) do
+    desc "The absolute path to the gpg homedir where the keyring is stored."
+
+    validate do |value|
+      unless value =~ /^\/[a-zA-Z0-9_-]+/
+        raise ArgumentError, "Invalid directory path for #{value}"
+      end
+    end
+  end
+
+  newparam(:sign_key) do
+    desc "Whether to sign the imported key or not. Defaults to false"
+
+    validate do |value|
+      unless value == true or value == false
+        raise ArgumentError, "Invalid value for sign_key.  Must be true or false."
+      end
+    end
+
+    defaultto false
   end
 
   newparam(:key_source) do

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,5 @@
-#
+# Class: gnupg::install
+# Class to install gnupg
 class gnupg::install {
 
   package { 'gnupg':

--- a/spec/system/gnupg_key_install_spec.rb
+++ b/spec/system/gnupg_key_install_spec.rb
@@ -13,6 +13,8 @@ describe 'gnupg_key install' do
       gnupg_key { 'jenkins_key':
         ensure     => present,
         user       => 'root',
+        gpg_home   => '/root/.gnupg',
+        sign_key   => true,
         key_source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
         key_id     => 'D50582E6',
       }
@@ -37,6 +39,8 @@ describe 'gnupg_key install' do
       gnupg_key { 'newrelic_key':
         ensure     => present,
         user       => 'root',
+        gpg_home   => '/root/.gnupg',
+        sign_key   => true,
         key_source => 'https://download.newrelic.com/548C16BF.gpg',
         key_id     => '548C16BF',
       }
@@ -61,6 +65,8 @@ describe 'gnupg_key install' do
       gnupg_key { 'root_key_foo':
         ensure    => present,
         user      => 'root',
+        gpg_home  => '/root/.gnupg',
+        sign_key  => true,
         key_server => 'hkp://pgp.mit.edu/',
         key_id     => '20BC0A86',
       }
@@ -102,6 +108,8 @@ describe 'gnupg_key install' do
         ensure     => present,
         key_id     => 20BC0A86,
         user       => root,
+        gpg_home   => 'root/.gnupg',
+        sign_key   => true,
         key_source => "puppet:///modules/gnupg/random.key",
       }
     EOS
@@ -125,6 +133,8 @@ describe 'gnupg_key install' do
       gnupg_key { 'jenkins_key':
         ensure     => present,
         user       => 'root',
+        gpg_home   => 'root'.gnupg',
+        sign_key   => true,
         key_source => '/santa/claus/does/not/exists/org/sorry/kids.key',
         key_id     => '40404040',
       }
@@ -140,6 +150,8 @@ describe 'gnupg_key install' do
       gnupg_key { 'jenkins_key':
         ensure     => present,
         user       => 'root',
+        gpg_home   => '/root/.gnupg',
+        sign_key   => true,
         key_source => 'http://foo.com/key-not-there.key',
         key_id     => '40404040',
       }


### PR DESCRIPTION
This adds 2 parameters to the gnupg_key type.  Both parameters are optional.  The first, `gpg_home` allows you to specify an alternate, non-default, gpg --homedir option.  This is required when using this type with hiera-eyaml-gpg as that keyring must live in a non-standard directory due to hiera-eyaml-gpg restrictions/limitations.

The second, `sign_key` allows the type to trust any added keys.  This is also nice for hiera-eyaml-gpg use on puppet masters to avoid having to manually sign keys that are instantiated via hiera lookups.