### PR TITLE
add ownertrust values to key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2017-09-26 - James Downs <james.downs@salesforce.com> - 1.3.0
+* add ownertrust_key parameter & unit tests
+  values: false, 2-6, matching (Undefined, Never, Marginal, Full, Ultimate)
+* fixup acceptance testing
+
 2017-07-27 - Scott Brimhall <sbrimhall@salesforce.com> - 1.2.4
 * add gpg_home and sign_key parameters & unit tests
 * Update rspec-system tests to support Ubuntu 14, 16, Centos 7

--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -79,6 +79,18 @@ Puppet::Type.newtype(:gnupg_key) do
     end
   end
 
+  newparam(:ownertrust_key) do
+    desc "Optional Ownertrust value for the imported key. Defaults to false (no ownertrust)"
+
+    validate do |value|
+      unless value == false or value =~ /^[2-6]/
+        raise ArgumentError, "Invalid value for sign_key.  Must be false, 2-6 (Undefined, Never, Marginal, Full, Ultimate)."
+      end
+    end
+
+    defaultto false
+  end
+
   newparam(:sign_key) do
     desc "Whether to sign the imported key or not. Defaults to false"
 

--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -84,7 +84,7 @@ Puppet::Type.newtype(:gnupg_key) do
 
     validate do |value|
       unless value == false or (0..6).include?(value)
-        raise ArgumentError, "Invalid value for sign_key.  Must be false, 2-6 (Undefined, Never, Marginal, Full, Ultimate)."
+        raise ArgumentError, "Invalid value for ownertrust_key.  Must be false, 2-6 (Undefined, Never, Marginal, Full, Ultimate)."
       end
     end
 

--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -83,7 +83,7 @@ Puppet::Type.newtype(:gnupg_key) do
     desc "Optional Ownertrust value for the imported key. Defaults to false (no ownertrust)"
 
     validate do |value|
-      unless value == false or (0..6).include?(value)
+      unless value == false or (2..6).include?(value)
         raise ArgumentError, "Invalid value for ownertrust_key.  Must be false, 2-6 (Undefined, Never, Marginal, Full, Ultimate)."
       end
     end

--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -83,7 +83,7 @@ Puppet::Type.newtype(:gnupg_key) do
     desc "Optional Ownertrust value for the imported key. Defaults to false (no ownertrust)"
 
     validate do |value|
-      unless value == false or value =~ /^[2-6]/
+      unless value == false or (0..6).include?(value)
         raise ArgumentError, "Invalid value for sign_key.  Must be false, 2-6 (Undefined, Never, Marginal, Full, Ultimate)."
       end
     end

--- a/spec/acceptance/gnupg_key_install_spec.rb
+++ b/spec/acceptance/gnupg_key_install_spec.rb
@@ -9,11 +9,14 @@ describe 'install gnupg keys' do
   it 'should install a public key from a http URL address' do
     pp = <<-EOS
       gnupg_key { 'jenkins_key':
-        ensure     => present,
-        user       => 'root',
-        key_type   => public,
-        key_source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-        key_id     => 'D50582E6',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_source     => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        key_id         => 'D50582E6',
       }
     EOS
 
@@ -33,11 +36,14 @@ describe 'install gnupg keys' do
   it 'should install a public key from a https URL address' do
     pp = <<-EOS
       gnupg_key { 'newrelic_key':
-        ensure     => present,
-        user       => 'root',
-        key_type   => public,
-        key_source => 'https://download.newrelic.com/548C16BF.gpg',
-        key_id     => '548C16BF',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_source     => 'https://download.newrelic.com/548C16BF.gpg',
+        key_id         => '548C16BF',
       }
     EOS
 
@@ -57,11 +63,14 @@ describe 'install gnupg keys' do
   it 'should install a public key from a key server' do
     pp = <<-EOS
       gnupg_key { 'root_key_foo':
-        ensure    => present,
-        user      => 'root',
-        key_type   => public,
-        key_server => 'hkp://pgp.mit.edu/',
-        key_id     => '20BC0A86',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_server     => 'hkp://pgp.mit.edu/',
+        key_id         => '20BC0A86',
       }
     EOS
 
@@ -85,10 +94,13 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'bye_bye_key':
-        ensure => absent,
-        user   => root,
-        key_type   => public,
-        key_id => 926FA9B9,
+        ensure         => absent,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_id         => 926FA9B9,
       }
     EOS
 
@@ -104,11 +116,14 @@ describe 'install gnupg keys' do
   it 'should install public key from the puppet fileserver/module repository' do
     pp = <<-EOS
       gnupg_key { 'add_key_by_remote_source':
-        ensure     => present,
-        user       => root,
-        key_type   => public,
-        key_id     => 926FA9B9,
-        key_source => "puppet:///modules/gnupg/random.public.key",
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_id         => 926FA9B9,
+        key_source     => "puppet:///modules/gnupg/random.public.key",
       }
     EOS
 
@@ -130,11 +145,14 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'add_key_by_local_file_path':
-        ensure     => present,
-        user       => root,
-        key_type   => public,
-        key_id     => 926FA9B9,
-        key_source => "/tmp/random.public.key",
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_id         => 926FA9B9,
+        key_source     => "/tmp/random.public.key",
       }
     EOS
 
@@ -156,11 +174,14 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'add_key_by_local_file_url':
-        ensure     => present,
-        user       => root,
-        key_type   => public,
-        key_id     => 926FA9B9,
-        key_source => "file:///tmp/random.public.key",
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_id         => 926FA9B9,
+        key_source     => "file:///tmp/random.public.key",
       }
     EOS
 
@@ -182,11 +203,14 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'public_key_from_string_content':
-        ensure      => present,
-        user        => root,
-        key_id      => 926FA9B9,
-        key_type    => public,
-        key_content => "#{key}"
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_id         => 926FA9B9,
+        key_type       => public,
+        key_content    => "#{key}"
       }
     EOS
 
@@ -209,11 +233,14 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'public_key_from_invalid_string_content':
-        ensure      => present,
-        user        => root,
-        key_id      => 926FA9B9,
-        key_type    => public,
-        key_content => "#{key}"
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_id         => 926FA9B9,
+        key_type       => public,
+        key_content    => "#{key}"
       }
     EOS
 
@@ -223,11 +250,14 @@ describe 'install gnupg keys' do
   it 'should not install a key, because local resource does not exists' do
     pp = <<-EOS
       gnupg_key { 'jenkins_key':
-        ensure     => present,
-        user       => 'root',
-        key_type   => public,
-        key_source => '/santa/claus/does/not/exists/org/sorry/kids.key',
-        key_id     => '40404040',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_source     => '/santa/claus/does/not/exists/org/sorry/kids.key',
+        key_id         => '40404040',
       }
     EOS
 
@@ -237,11 +267,14 @@ describe 'install gnupg keys' do
   it 'should fail to install a public key, because there is no content at the supplied URL address' do
     pp = <<-EOS
       gnupg_key { 'jenkins_key':
-        ensure     => present,
-        user       => 'root',
-        key_type   => public,
-        key_source => 'http://foo.com/key-not-there.key',
-        key_id     => '40404040',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_type       => public,
+        key_source     => 'http://foo.com/key-not-there.key',
+        key_id         => '40404040',
       }
     EOS
 
@@ -253,11 +286,14 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'add_private_key_by_local_file_path':
-        ensure     => present,
-        user       => root,
-        key_id     => 926FA9B9,
-        key_type   => private,
-        key_source => '/tmp/random.private.key'
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_id         => 926FA9B9,
+        key_type       => private,
+        key_source     => '/tmp/random.private.key'
       }
     EOS
 
@@ -279,11 +315,14 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'add_private_key_by_local_file_path':
-        ensure     => present,
-        user       => root,
-        key_id     => 926FA9B9,
-        key_type   => private,
-        key_source => 'file:///tmp/random.private.key'
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_id         => 926FA9B9,
+        key_type       => private,
+        key_source     => 'file:///tmp/random.private.key'
       }
     EOS
 
@@ -305,11 +344,14 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'private_key_from_string_content':
-        ensure      => present,
-        user        => root,
-        key_id      => 926FA9B9,
-        key_type    => private,
-        key_content => "#{key}"
+        ensure         => present,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_id         => 926FA9B9,
+        key_type       => private,
+        key_content    => "#{key}"
       }
     EOS
 
@@ -333,10 +375,13 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'bye_bye_key':
-        ensure   => absent,
-        user     => root,
-        key_id   => 926FA9B9,
-        key_type => private
+        ensure         => absent,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_id         => 926FA9B9,
+        key_type       => private
       }
     EOS
 
@@ -365,10 +410,13 @@ describe 'install gnupg keys' do
 
     pp = <<-EOS
       gnupg_key { 'bye_bye_key':
-        ensure   => absent,
-        user     => root,
-        key_id   => 926FA9B9,
-        key_type => both
+        ensure         => absent,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_id         => 926FA9B9,
+        key_type       => both
       }
     EOS
 

--- a/spec/system/gnupg_key_install_spec.rb
+++ b/spec/system/gnupg_key_install_spec.rb
@@ -11,12 +11,13 @@ describe 'gnupg_key install' do
   it 'should install a public key from a HTTP URL address' do
     pp = <<-EOS.unindent
       gnupg_key { 'jenkins_key':
-        ensure     => present,
-        user       => 'root',
-        gpg_home   => '/root/.gnupg',
-        sign_key   => true,
-        key_source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-        key_id     => 'D50582E6',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_source     => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        key_id         => 'D50582E6',
       }
     EOS
 
@@ -37,12 +38,13 @@ describe 'gnupg_key install' do
   it 'should install a public key from a HTTPS URL address' do
     pp = <<-EOS.unindent
       gnupg_key { 'newrelic_key':
-        ensure     => present,
-        user       => 'root',
-        gpg_home   => '/root/.gnupg',
-        sign_key   => true,
-        key_source => 'https://download.newrelic.com/548C16BF.gpg',
-        key_id     => '548C16BF',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_source     => 'https://download.newrelic.com/548C16BF.gpg',
+        key_id         => '548C16BF',
       }
     EOS
 
@@ -63,12 +65,13 @@ describe 'gnupg_key install' do
   it 'should install a public key from a key server' do
     pp = <<-EOS.unindent
       gnupg_key { 'root_key_foo':
-        ensure    => present,
-        user      => 'root',
-        gpg_home  => '/root/.gnupg',
-        sign_key  => true,
-        key_server => 'hkp://pgp.mit.edu/',
-        key_id     => '20BC0A86',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_server     => 'hkp://pgp.mit.edu/',
+        key_id         => '20BC0A86',
       }
     EOS
 
@@ -105,12 +108,13 @@ describe 'gnupg_key install' do
   it 'should install public key from the puppet fileserver/module repository' do
     pp = <<-EOS.unindent
       gnupg_key {'add_key_by_remote_source':
-        ensure     => present,
-        key_id     => 20BC0A86,
-        user       => root,
-        gpg_home   => 'root/.gnupg',
-        sign_key   => true,
-        key_source => "puppet:///modules/gnupg/random.key",
+        ensure         => present,
+        key_id         => 20BC0A86,
+        user           => root,
+        ownertrust_key => 6,
+        gpg_home       => 'root/.gnupg',
+        sign_key       => true,
+        key_source     => "puppet:///modules/gnupg/random.key",
       }
     EOS
 
@@ -131,12 +135,13 @@ describe 'gnupg_key install' do
   it 'should not install a public key, because local resource does not exists' do
     pp = <<-EOS.unindent
       gnupg_key { 'jenkins_key':
-        ensure     => present,
-        user       => 'root',
-        gpg_home   => 'root'.gnupg',
-        sign_key   => true,
-        key_source => '/santa/claus/does/not/exists/org/sorry/kids.key',
-        key_id     => '40404040',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => 'root'.gnupg',
+        sign_key       => true,
+        key_source     => '/santa/claus/does/not/exists/org/sorry/kids.key',
+        key_id         => '40404040',
       }
     EOS
 
@@ -148,12 +153,13 @@ describe 'gnupg_key install' do
   it 'should fail to install a public key, because there is no content at the supplied URL address' do
     pp = <<-EOS.unindent
       gnupg_key { 'jenkins_key':
-        ensure     => present,
-        user       => 'root',
-        gpg_home   => '/root/.gnupg',
-        sign_key   => true,
-        key_source => 'http://foo.com/key-not-there.key',
-        key_id     => '40404040',
+        ensure         => present,
+        user           => 'root',
+        ownertrust_key => 6,
+        gpg_home       => '/root/.gnupg',
+        sign_key       => true,
+        key_source     => 'http://foo.com/key-not-there.key',
+        key_id         => '40404040',
       }
     EOS
 

--- a/spec/unit/puppet/type/gnupg_key_spec.rb
+++ b/spec/unit/puppet/type/gnupg_key_spec.rb
@@ -27,8 +27,9 @@ describe Puppet::Type.type(:gnupg_key) do
   end
 
   it 'should not accept ownertrust_key out of range numeric value' do
-    @gnupg_key[:ownertrust_key] = 9
-    expect(@gnupg_key[:ownertrust_key]).to raise_error(Puppet::Error, /Invalid value for ownertrust_key*/)
+    expect {
+      @gnupg_key[:ownertrust_key] = 9 
+    }.to raise_error(Puppet::Error, /Invalid value for ownertrust_key*/)
   end
 
   it 'should accept sign_key' do

--- a/spec/unit/puppet/type/gnupg_key_spec.rb
+++ b/spec/unit/puppet/type/gnupg_key_spec.rb
@@ -23,12 +23,12 @@ describe Puppet::Type.type(:gnupg_key) do
 
   it 'should accept ownertrust_key numeric value' do
     @gnupg_key[:ownertrust_key] = 6
-    expect(@gnupg_key[:sign_key]).to eq 6
+    expect(@gnupg_key[:ownertrust_key]).to eq 6
   end
 
   it 'should not accept ownertrust_key out of range numeric value' do
     @gnupg_key[:ownertrust_key] = 9
-    expect(@gnupg_key[:sign_key]).to raise_error(Puppet::ArgumentError, /Invalid value for sign_key*/)
+    expect(@gnupg_key[:ownertrust_key]).to raise_error(Puppet::ArgumentError, /Invalid value for sign_key*/)
   end
 
   it 'should accept sign_key' do

--- a/spec/unit/puppet/type/gnupg_key_spec.rb
+++ b/spec/unit/puppet/type/gnupg_key_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Type.type(:gnupg_key) do
 
   it 'should accept ownertrust_key false' do
     @gnupg_key[:ownertrust_key] = false
-    expect(@gnupg_key[:sign_key]).to eq false
+    expect(@gnupg_key[:ownertrust_key]).to eq false
   end
 
   it 'should accept ownertrust_key numeric value' do
@@ -28,7 +28,7 @@ describe Puppet::Type.type(:gnupg_key) do
 
   it 'should not accept ownertrust_key out of range numeric value' do
     @gnupg_key[:ownertrust_key] = 9
-    expect(@gnupg_key[:sign_key]).to raise_error(Puppet::Error, /Invalid value for sign_key*/)
+    expect(@gnupg_key[:sign_key]).to raise_error(Puppet::ArgumentError, /Invalid value for sign_key*/)
   end
 
   it 'should accept sign_key' do

--- a/spec/unit/puppet/type/gnupg_key_spec.rb
+++ b/spec/unit/puppet/type/gnupg_key_spec.rb
@@ -28,7 +28,7 @@ describe Puppet::Type.type(:gnupg_key) do
 
   it 'should not accept ownertrust_key out of range numeric value' do
     @gnupg_key[:ownertrust_key] = 9
-    expect(@gnupg_key[:ownertrust_key]).to raise_error(Puppet::ArgumentError, /Invalid value for sign_key*/)
+    expect(@gnupg_key[:ownertrust_key]).to raise_error(Puppet::Error, /Invalid value for ownertrust_key*/)
   end
 
   it 'should accept sign_key' do

--- a/spec/unit/puppet/type/gnupg_key_spec.rb
+++ b/spec/unit/puppet/type/gnupg_key_spec.rb
@@ -16,6 +16,21 @@ describe Puppet::Type.type(:gnupg_key) do
     expect(@gnupg_key[:gpg_home]).to eq '/root/.gnupg'
   end
 
+  it 'should accept ownertrust_key false' do
+    @gnupg_key[:ownertrust_key] = false
+    expect(@gnupg_key[:sign_key]).to eq false
+  end
+
+  it 'should accept ownertrust_key numeric value' do
+    @gnupg_key[:ownertrust_key] = 6
+    expect(@gnupg_key[:sign_key]).to eq 6
+  end
+
+  it 'should not accept ownertrust_key out of range numeric value' do
+    @gnupg_key[:ownertrust_key] = 9
+    expect(@gnupg_key[:sign_key]).to raise_error(Puppet::Error, /Invalid value for sign_key*/)
+  end
+
   it 'should accept sign_key' do
     @gnupg_key[:sign_key] = true
     expect(@gnupg_key[:sign_key]).to eq true


### PR DESCRIPTION
This PR adds the ability to specify an ownertrust on a GPG key, which allows a public key to be used without requiring a private key to be present for signing. This is useful in cases such as on systems just doing duplicity backup encryption, but not decryption, or other signing.

![](https://media.giphy.com/media/3oz8xHQlKq9NkkmcoM/giphy.gif)