### PR TITLE
All values are strings ; treat ownertrust integers properly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2017-10-02 - James Downs <james.downs@salesforce.com> - 1.3.1
+* all values are strings in this version of puppet, so handle
+  the ownerkey values appropriately
+
 2017-09-26 - James Downs <james.downs@salesforce.com> - 1.3.0
 * add ownertrust_key parameter & unit tests
   values: false, 2-6, matching (Undefined, Never, Marginal, Full, Ultimate)

--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -83,7 +83,7 @@ Puppet::Type.newtype(:gnupg_key) do
     desc "Optional Ownertrust value for the imported key. Defaults to false (no ownertrust)"
 
     validate do |value|
-      unless value == false or (2..6).include?(value)
+      unless value == false or (2..6).include?(value.to_i)
         raise ArgumentError, "Invalid value for ownertrust_key.  Must be false, 2-6 (Undefined, Never, Marginal, Full, Ultimate)."
       end
     end

--- a/spec/unit/puppet/type/gnupg_key_spec.rb
+++ b/spec/unit/puppet/type/gnupg_key_spec.rb
@@ -22,13 +22,13 @@ describe Puppet::Type.type(:gnupg_key) do
   end
 
   it 'should accept ownertrust_key numeric value' do
-    @gnupg_key[:ownertrust_key] = 6
-    expect(@gnupg_key[:ownertrust_key]).to eq 6
+    @gnupg_key[:ownertrust_key] = "6"
+    expect(@gnupg_key[:ownertrust_key]).to eq "6"
   end
 
   it 'should not accept ownertrust_key out of range numeric value' do
     expect {
-      @gnupg_key[:ownertrust_key] = 9 
+      @gnupg_key[:ownertrust_key] = "9"
     }.to raise_error(Puppet::Error, /Invalid value for ownertrust_key*/)
   end
 


### PR DESCRIPTION
Values in this version of puppet are all strings. This change treats them properly.