### PR TITLE
Fix bug with ownertrust parameter in provider.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2017-11-15 - Scott Brimhall <sbrimhall@salesforce.com> - 1.3.3
+* Fix gpg command in provider to pass in --homedir if necessary.
+
 2017-10-03 - James Downs <james.downs@salesforce.com> - 1.3.2
 * ownertrust requires fingerprint
 
@@ -54,7 +57,7 @@ Special thanks to Tobias Clemson (https://github.com/tobyclemson)
 * bugfix for https keys
 
 2014-08-17 - Dejan Golja <dejan@golja.org> - 0.0.4
-* Update metadata.json and removed Modulefile due to 
+* Update metadata.json and removed Modulefile due to
   as of Puppet 3.6 the Modulefile has been deprecated
 
 2014-03-16 - Dejan Golja <dejan@golja.org> - 0.0.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ puppetversion = ENV.key?('PUPPET_GEM_VERSION') ? ENV['PUPPET_GEM_VERSION'] : '>=
 facterversion = ENV.key?('FACTER_GEM_VERSION') ? ENV['FACTER_GEM_VERSION'] : '>= 2.4.6'
 
 group :development, :test do
-  gem 'rake',                               :require => false
   gem 'puppet', puppetversion,              :require => false
   gem 'facter', facterversion,              :require => false
   gem 'rspec-core','~> 3.6.0',              :require => false
@@ -15,9 +14,11 @@ group :development, :test do
   gem 'json',                               :require => false
 
   if RUBY_VERSION >= '1.9.3' && RUBY_VERSION < '2.0'
+    gem 'rake', '< 12.3.0',                 :require => false
     gem 'public_suffix', '~> 1.4.6',        :require => false
     gem 'nokogiri', '~> 1.6.8',             :require => false
   elsif RUBY_VERSION >= '2.0' && RUBY_VERSION < '3.0'
+    gem 'rake',                             :require => false
     # metadata-json-lint requires >= 2.0,   :require => false
     gem 'metadata-json-lint',               :require => false
     # rubocop requires ruby >= 2.0

--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -33,16 +33,19 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
     if resource[:ownertrust_key]
       begin
         fingerprint_command = "gpg --fingerprint --with-colons #{resource[:key_id]} | awk -F: '$1 == \"fpr\" {print $10;}'"
+        Puppet.debug("Fingerprint command was: #{fingerprint_command}")
         fingerprint = Puppet::Util::Execution.execute(fingerprint_command, :uid => user_id)
         fingerprint.strip!
+        Puppet.debug("Fingerprint is: #{fingerprint}")
       rescue Puppet::ExecutionFailure => e
         raise Puppet::Error, "Could not determine fingerprint for  #{resource[:key_id]} for user #{resource[:user]}: #{fingerprint}"
       end
       ownertrust_command = "echo \"#{fingerprint}:#{resource[:ownertrust_key]}:\" | #{gpg_command} --batch --yes --import-ownertrust"
+      Puppet.debug("Ownertrust command is: #{ownertrust_command}")
       begin
         sign_output = Puppet::Util::Execution.execute(ownertrust_command, :uid => user_id, :failonfail => true)
       rescue Puppet::ExecutionFailure => e
-        raise Puppet::Error, "Key #{resource[:key_id]} owner trust could not be imported."
+        raise Puppet::Error, "Key #{resource[:key_id]} owner trust could not be imported: #{e}"
       end
     end
   end

--- a/lib/puppet/provider/gnupg_key/gnupg.rb
+++ b/lib/puppet/provider/gnupg_key/gnupg.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:gnupg_key).provide(:gnupg) do
   def ownertrust_key
     if resource[:ownertrust_key]
       begin
-        fingerprint_command = "gpg --fingerprint --with-colons #{resource[:key_id]} | awk -F: '$1 == \"fpr\" {print $10;}'"
+        fingerprint_command = "#{gpg_command} --fingerprint --with-colons #{resource[:key_id]} | awk -F: '$1 == \"fpr\" {print $10;}'"
         Puppet.debug("Fingerprint command was: #{fingerprint_command}")
         fingerprint = Puppet::Util::Execution.execute(fingerprint_command, :uid => user_id)
         fingerprint.strip!

--- a/spec/acceptance/nodesets/centos-72-x64.yml
+++ b/spec/acceptance/nodesets/centos-72-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-72-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.2-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.2-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: debug
+  type: git

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  centos-72-x64:
+  ubuntu-server-1404-x64:
     roles:
       - master
-    platform: el-7-x86_64
-    box : puppetlabs/centos-7.2-64-nocm
-    box_url : https://vagrantcloud.com/puppetlabs/boxes/centos-7.2-64-nocm
-    hypervisor : vagrant
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
 CONFIG:
   log_level: debug
   type: git


### PR DESCRIPTION
This fixes a bug with the ownertrust parameter.  It is not currently set to pass in the proper `--homedir` option if that's set.  That means it doesn't currently work if you try to use it on a key for hiera on a puppet master.  This uses the already defined gpg_command variable so it works.

Also, this sets Ubuntu 14.04 as the default nodeset for beaker/acceptance testing instead of CentOS 7.2.  Also adds some debug logging in the gnupg_key provider that I used to find the bug to begin with.